### PR TITLE
Fix up definitions dir so that newly generated pipelines will pass rake ...

### DIFF
--- a/templates/Rakefile
+++ b/templates/Rakefile
@@ -36,16 +36,16 @@ Pipely::Tasks::Definition.new do |t|
 end
 
 namespace :build do
-  desc "Copy pipeline definitions to dist/"
-  task :dist do
-    dist_dir = File.join(File.dirname(__FILE__), 'dist')
-    mkdir_p(dist_dir)
+  desc "Compile definition"
+  task :definition do
+    definition_dir = File.join(File.dirname(__FILE__), 'definitions')
+    mkdir_p(definition_dir)
 
-    Rake::Task["definition"].invoke(dist_dir)
+    Rake::Task["definition"].invoke(definition_dir)
   end
 
   desc "Run all tests for CI"
-  task :continuous => [:spec, :dist]
+  task :continuous => [:spec, :definition]
 end
 
 task :default => :spec


### PR DESCRIPTION
...build:continuous

@mattgillooly 
